### PR TITLE
Step 0 – CI & Pages bootstrap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,21 @@ jobs:
           else
             echo "BASE_HREF=/$REPO/" >> $GITHUB_ENV
           fi
+      # BEGIN PATCH: Fetch demo assets and PWA icons
+      - name: Fetch demo assets
+        run: |
+          mkdir -p assets/demo web/icons
+          curl -L "https://placehold.co/1024x1024/png?text=Grey+Ball"   -o assets/demo/grey_ball.png
+          curl -L "https://placehold.co/1024x1024/png?text=Chrome+Ball" -o assets/demo/chrome_ball.png
+          curl -L "https://placehold.co/1280x720/png?text=ColorChecker" -o assets/demo/colorchecker.png
+
+      - name: Generate PWA icons
+        run: |
+          sudo apt-get update && sudo apt-get install -y imagemagick fonts-dejavu-core
+          mkdir -p web/icons
+          convert -size 512x512 xc:"#121212" -gravity center -font DejaVu-Sans -pointsize 300 label:"🎬" -flatten web/icons/icon-512.png
+          convert web/icons/icon-512.png -resize 192x192 web/icons/icon-192.png
+      # END PATCH: Fetch demo assets and PWA icons
 
       - run: flutter build web --release --base-href "$BASE_HREF" --dart-define=WEB_BUILD=true
       - run: cp build/web/index.html build/web/404.html

--- a/lib/features/day_dashboard/day_dashboard.dart
+++ b/lib/features/day_dashboard/day_dashboard.dart
@@ -9,9 +9,21 @@ class DayDashboardPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Day Dashboard'),
       ),
-      body: const Center(
-        child: Text('Day Dashboard coming soon'),
-      ),
+  body: Center(
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text('Day Dashboard coming soon'),
+        const SizedBox(height: 16),
+        Image.asset(
+          'assets/demo/grey_ball.png',
+          width: 200,
+          height: 200,
+        ),
+      ],
+    ),
+  ),
+  ), ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,3 +28,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/demo/


### PR DESCRIPTION
This PR initializes the CI and GitHub Pages deployment for the project (project page with base href /vfx_sheet/).

Changes include:
- Added .github/workflows/deploy.yml with Flutter build steps, dynamic BASE_HREF detection, copying index.html to 404.html, and deployment via gh-pages action.
- Added steps to download demo images from placehold.co and generate PWA icons using ImageMagick in the workflow.
- Updated pubspec.yaml to include assets/demo/ in the Flutter assets bundle so demo images are bundled.
- Updated Day Dashboard to display a demo image via Image.asset for offline-friendly preview.

After merge, CI should run and deploy the web build to GitHub Pages.