### PR TITLE
Step 1 – Skeleton & Navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart';
 
+import 'features/day_dashboard/day_dashboard.dart';
+import 'features/shots/shots.dart';
+import 'features/camera_lens/camera_lens.dart';
+import 'features/exports/exports.dart';
+import 'features/settings/settings.dart';
+
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   runApp(const VfxSheetApp());
@@ -14,37 +20,63 @@ class VfxSheetApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'On-Set VFX Sheet',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        useMaterial3: true,
-        brightness: Brightness.dark,
-        colorSchemeSeed: Colors.blue,
-      ),
-      supportedLocales: const [
-        Locale('en'),
-        Locale('sk'),
-      ],
+      theme: ThemeData.dark(useMaterial3: true),
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      home: const HomePage(),
+      supportedLocales: const [
+        Locale('en', ''),
+        Locale('sk', ''),
+      ],
+      home: const MainNavigation(),
     );
   }
 }
 
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+class MainNavigation extends StatefulWidget {
+  const MainNavigation({super.key});
+
+  @override
+  State<MainNavigation> createState() => _MainNavigationState();
+}
+
+class _MainNavigationState extends State<MainNavigation> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _pages = const [
+    DayDashboardPage(),
+    ShotsPage(),
+    CameraLensPage(),
+    ExportsPage(),
+    SettingsPage(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('On-Set VFX Sheet'),
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: _pages,
       ),
-      body: const Center(
-        child: Text('Welcome to On-Set VFX Sheet'),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        type: BottomNavigationBarType.fixed,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.calendar_today), label: 'Day'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Shots'),
+          BottomNavigationBarItem(icon: Icon(Icons.photo_camera), label: 'Camera/Lens'),
+          BottomNavigationBarItem(icon: Icon(Icons.download), label: 'Exports'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
       ),
     );
   }


### PR DESCRIPTION
This PR introduces the initial app skeleton for the On-Set VFX Sheet Flutter PWA.

- Adds a minimal Material 3 dark themed app.
- Implements a bottom navigation bar with five tabs: Day, Shots, Camera/Lens, Exports and Settings.
- Each tab shows its own page widget placeholder.

This sets up the navigation structure for future features like data storage, day dashboard, quick VFX panel, exports and settings.