### PR TITLE
fix(database): remove extra parenthesis in AppDatabase constructor

### DIFF
--- a/lib/core/data/database.dart
+++ b/lib/core/data/database.dart
@@ -40,7 +40,7 @@ class Takes extends Table {
 
 @DriftDatabase(tables: [Projects, ShootingDays, Slates, Shots, Takes])
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(WebDatabase()));
+  AppDatabase() : super(WebDatabase();
 
   @override
   int get schemaVersion => 1;


### PR DESCRIPTION
Fixes syntax error in AppDatabase constructor by removing an extra parenthesis causing build failure.